### PR TITLE
Names for radios in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,8 +336,8 @@ $('input').iCheck('destroy');
 <pre class="markup">
 &lt;input type="checkbox">
 &lt;input type="checkbox" checked>
-&lt;input type="radio">
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck">
+&lt;input type="radio" name="iCheck" checked>
 </pre>
               </li>
               <li>
@@ -524,8 +524,8 @@ $(document).ready(function(){
 <pre class="markup">
 &lt;input type="checkbox">
 &lt;input type="checkbox" checked>
-&lt;input type="radio">
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck">
+&lt;input type="radio" name="iCheck" checked>
 </pre>
               </li>
               <li>
@@ -706,8 +706,8 @@ $(document).ready(function(){
 <pre class="markup">
 &lt;input type="checkbox">
 &lt;input type="checkbox" checked>
-&lt;input type="radio">
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck">
+&lt;input type="radio" name="iCheck" checked>
 </pre>
               </li>
               <li>
@@ -908,10 +908,10 @@ $(document).ready(function(){
 &lt;input type="checkbox" checked>
 &lt;label>Checkbox 2&lt;/label>
 
-&lt;input type="radio">
+&lt;input type="radio" name="iCheck">
 &lt;label>Radio button 1&lt;/label>
 
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck" checked>
 &lt;label>Radio button 2&lt;/label>
 </pre>
               </li>
@@ -1074,8 +1074,8 @@ $(document).ready(function(){
 <pre class="markup">
 &lt;input type="checkbox">
 &lt;input type="checkbox" checked>
-&lt;input type="radio">
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck">
+&lt;input type="radio" name="iCheck" checked>
 </pre>
               </li>
               <li>
@@ -1206,8 +1206,8 @@ $(document).ready(function(){
 <pre class="markup">
 &lt;input type="checkbox">
 &lt;input type="checkbox" checked>
-&lt;input type="radio">
-&lt;input type="radio" checked>
+&lt;input type="radio" name="iCheck">
+&lt;input type="radio" name="iCheck" checked>
 </pre>
               </li>
               <li>
@@ -1256,10 +1256,10 @@ $(document).ready(function(){
 &lt;/label>
 
 &lt;label for="baz[1]">Bar&lt;/label>
-&lt;input type="radio" name="quux[2]" id="baz[1]" checked>
+&lt;input type="radio" name="iCheck" name="quux[2]" id="baz[1]" checked>
 
 &lt;label for="baz[2]">Bar&lt;/label>
-&lt;input type="radio" name="quux[2]" id="baz[2]">
+&lt;input type="radio" name="iCheck" name="quux[2]" id="baz[2]">
 </pre>
         <p class="offset">With default options you'll get nearly this:</p>
 <pre class="markup">
@@ -1269,10 +1269,10 @@ $(document).ready(function(){
 &lt;/label>
 
 &lt;label for="baz[1]">Bar&lt;/label>
-&lt;div class="iradio checked">&lt;input type="radio" name="quux[2]" id="baz[1]" checked>&lt;/div>
+&lt;div class="iradio checked">&lt;input type="radio" name="iCheck" name="quux[2]" id="baz[1]" checked>&lt;/div>
 
 &lt;label for="baz[2]">Bar&lt;/label>
-&lt;div class="iradio">&lt;input type="radio" name="quux[2]" id="baz[2]">&lt;/div>
+&lt;div class="iradio">&lt;input type="radio" name="iCheck" name="quux[2]" id="baz[2]">&lt;/div>
 </pre>
         <p>By default, iCheck doesn't provide any CSS styles for wrapper divs (if you don't use skins).</p>
         <h4 class="options">Options</h4>


### PR DESCRIPTION
Radios don't work when they don't have name.
That can make some people confused when they use your examples

// sorry, I replaced correct example
