### PR TITLE
Limiting the scope of resetting the radios

### DIFF
--- a/jquery.icheck.js
+++ b/jquery.icheck.js
@@ -304,7 +304,7 @@
 
       // Toggle assigned radio buttons
       if (state == _checked && node[_type] == _radio && node.name) {
-        $('input[name="' + node.name + '"]').each(function() {
+        $('input[name="' + node.name + '"]', parent.parent()).each(function() {
           if (this !== node && $(this).data(_iCheck)) {
             off($(this), state);
           };


### PR DESCRIPTION
Just a super small thing so that it doesn't set every radio that has the same name to "off".
