### PR TITLE
Calling tidy(input[, callback]) without a callback may throw an error (zepto)

### DIFF
--- a/zepto.icheck.js
+++ b/zepto.icheck.js
@@ -375,7 +375,10 @@
     if (input.data(_iCheck)) {
 
       // Remove everything except input
-      input.parent().html(input.attr('style', input.data(_iCheck).s || '').trigger(callback || ''));
+      input.parent().html(input.attr('style', input.data(_iCheck).s || ''));
+      if(callback) {
+         input.trigger(callback);
+      };
 
       // Unbind events
       input.off('.i').unwrap();


### PR DESCRIPTION
`tidy()` calls `$.trigger()`. Invoking this function without a parameter fails with Zepto.

It fails with a `UNSPECIFIED_EVENT_TYPE_ERR` (1) Dom exception, because Zepto creates an event without a type.

This pull request adds a check to see if `callback` is defined before calling trigger.

(1): http://www.w3.org/TR/DOM-Level-2-Events/events.html
