### PR TITLE
Update jquery.icheck.js

### DIFF
--- a/jquery.icheck.js
+++ b/jquery.icheck.js
@@ -187,7 +187,7 @@
               if (_mobile) {
                 event.stopPropagation();
               } else {
-                return false;
+                return true;
               };
             };
           });
@@ -263,7 +263,7 @@
             if (_mobile) {
               event.stopPropagation();
             } else {
-              return false;
+              return true;
             };
           };
         });


### PR DESCRIPTION
return false prevents the event from bubbling up the DOM tree. in some cases this is not wanted
