### PR TITLE
General classes added to the top level div

### DIFF
--- a/icheck.js
+++ b/icheck.js
@@ -154,7 +154,7 @@
           ariaID = _iCheck + '-' + Math.random().toString(36).substr(2,6),
 
           // Parent & helper
-          parent = '<div class="' + className + '" ' + (aria ? 'role="' + node[_type] + '" ' : ''),
+          parent = '<div class="' + _iCheck + " " + _iCheck + "-" + node[_type] + " " + className + '" ' + (aria ? 'role="' + node[_type] + '" ' : ''),
           helper;
 
         // Set ARIA "labelledby"


### PR DESCRIPTION
The top level div has a specific class to the style (for example, "icheckbox_square-grey"), but no general classes to apply styles independent of the skin chosen. This change adds additional classes: a general "iCheck" and also one for the type of input, "iCheck-checkbox" or "iCheck-radio".

Let me know if there is a better way that this should be done.  
