### PR TITLE
Fixed issue with keydown event

### DIFF
--- a/icheck.js
+++ b/icheck.js
@@ -947,7 +947,11 @@
                 operate(self, parent, key, 'click', false, true); // 'toggle' method
               }
 
-              hashes[key].keydown = hashes[lastKey].keydown = false;
+              hashes[key].keydown = false;
+
+              if (lastKey && hashes[lastKey]) {
+                  hashes[lastKey].keydown = false;
+              }
 
             // keydown
             } else {


### PR DESCRIPTION
Fixed a problem when tabbing from an element in the DOM to an icheck element. (tested in chrome and IE)
