### PR TITLE
Reorder parent construction wrap slightly to avoid layout thrashing

### DIFF
--- a/icheck.js
+++ b/icheck.js
@@ -172,6 +172,9 @@
             parent += '"';
           });
         }
+        
+        // Cache whether or not the parent is static positioned
+        parentIsStatic = parent.css('position') == 'static'
 
         // Wrap input
         parent = self.wrap(parent + '/>')[_callback]('ifCreated').parent().append(settings.insert);
@@ -183,7 +186,7 @@
         self.data(_iCheck, {o: settings, s: self.attr('style')}).css(hide);
         !!settings.inheritClass && parent[_add](node.className || '');
         !!settings.inheritID && id && parent.attr('id', _iCheck + '-' + id);
-        parent.css('position') == 'static' && parent.css('position', 'relative');
+        parentIsStatic && parent.css('position', 'relative');
         operate(self, true, _update);
 
         // Label events


### PR DESCRIPTION
I know the 1.x branch won't be used much anymore, but thought I'd submit this just in case :)

Was optimising a project I use iCheck in and found that there was a synchronous layout forced by the `parent.css('position') == 'static'` line, since the parent element had been `wrap()`ed a few lines earlier (so the browser has to recalculate styles to know what position it has now).

By moving the position check above the wrapping the browser can just use its existing style calc and so a reflow isn't forced.

The page I was working on was particularly complex, so the recalc was quite expensive, but pretty minor overall
