### PR TITLE
Stop setting radio checked state on tab movement

### DIFF
--- a/icheck.js
+++ b/icheck.js
@@ -942,8 +942,8 @@
             // keyup
             if (emitter == 'keyup') {
 
-              // spacebar or arrow
-              if (self.type == 'checkbox' && event.keyCode == 32 && settings.keydown || self.type == 'radio' && !self.checked) {
+              // spacebar for checkbox/radio
+              if ((self.type == 'checkbox' || (self.type == 'radio' && !self.checked)) && event.keyCode == 32 && settings.keydown) {
                 operate(self, parent, key, 'click', false, true); // 'toggle' method
               }
 


### PR DESCRIPTION
Any keyup event (not only tab) on a radio button would call the operate() function, causing an unchecked radio button to toggle to a checked state.

This fix restricts this call to only occur in these conditions:
- The keyCode is that of the spacebar
- The radio button is currently in an unchecked state.

This fix addresses issue #327 
