### PR TITLE
openharmony support

### DIFF
--- a/icheck.js
+++ b/icheck.js
@@ -28,7 +28,7 @@
     _callback = 'trigger',
     _label = 'label',
     _cursor = 'cursor',
-    _mobile = /ip(hone|od|ad)|android|blackberry|windows phone|opera mini|silk/i.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    _mobile = /ip(hone|od|ad)|android|openharmony|blackberry|windows phone|opera mini|silk/i.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 
   // Plugin init
   $.fn[_iCheck] = function(options, fire) {


### PR DESCRIPTION
_mobile 判断中少了新增的 openharmony 鸿蒙系统手机，导致鸿蒙设备中点击无效，需要在判断中增加鸿蒙设备

_mobile = /ipad|iphone|ipod|android|android|openharmony|blackberry|windows phone|opera mini|silk/i.test(navigator.userAgent);
